### PR TITLE
make SingleResult.value public

### DIFF
--- a/Sources/Statement.swift
+++ b/Sources/Statement.swift
@@ -24,7 +24,7 @@ public enum SingleResult<T> {
 	case NoResult
 	case Result(T)
 	
-	var value : T? {
+	public var value : T? {
 		switch self {
 		case .Result(let value): return value
 		case .NoResult: return nil


### PR DESCRIPTION
Minor fix: make the value field public so that its usable.
