### PR TITLE
Update Sqlable.swift

### DIFF
--- a/Sources/Sqlable.swift
+++ b/Sources/Sqlable.swift
@@ -69,8 +69,7 @@ public protocol Sqlable {
 public extension Sqlable {
 	static var tableName : String {
 		let typeName = "table_\(Mirror(reflecting: self).subjectType)"
-		return typeName
-			.substring(to: typeName.index(typeName.endIndex, offsetBy: -5))
+		return String(typeName[..<typeName.index(typeName.endIndex, offsetBy: -5)])
 			.lowercased()
 	}
 	


### PR DESCRIPTION
Update 'tablename' variable to use 'String slicing' instead of 'substring(from:)' because it's deprecated.